### PR TITLE
Renovate full stack to v3.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,17 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+
+    - name: Run Go tests
+      run: cd ./demo/src && go test -v ./...
+
+    - name: Run Go vet
+      run: cd ./demo/src && go vet ./...
+
     - id: 'auth'
       uses: 'google-github-actions/auth@v2'
       with:
@@ -41,7 +52,6 @@ jobs:
     # Setup gcloud CLI
     - uses: 'google-github-actions/setup-gcloud@v2'
       with:
-#        service_account_key: ${{ secrets.GK_SA_KEY }}
         project_id: ${{ secrets.GKE_PROJECT }}
 
     # Configure Docker to use the gcloud command-line tool as a credential
@@ -57,11 +67,10 @@ jobs:
       with:
         cluster_name: ${{ env.GKE_CLUSTER }}
         location: ${{ env.GKE_ZONE }}
-#        credentials: ${{ secrets.GK_SA_KEY }}
         project_id: ${{ secrets.GKE_PROJECT }}
 
-    # Build the Docker image
-    - name: Build
+    # Build the Docker image for GAR
+    - name: Build GAR image
       run: |-
         cd ./demo && docker build \
           --tag "$GAR_ZONE-docker.pkg.dev/$PROJECT_ID/$GAR_REPO/$IMAGE:$IMAGE_TAG" \
@@ -69,8 +78,8 @@ jobs:
           --build-arg GITHUB_REF="$GITHUB_REF" \
           .
 
-    # Push the Docker image to Google Container Registry
-    - name: Publish
+    # Push the Docker image to Google Artifact Registry
+    - name: Publish to GAR
       run: |-
         docker push "$GAR_ZONE-docker.pkg.dev/$PROJECT_ID/$GAR_REPO/$IMAGE:$IMAGE_TAG"
 
@@ -82,23 +91,15 @@ jobs:
         kubectl rollout restart deploy
 
     # Login to GitHub Container Registry
-    - name: 'Login to GitHub Container Registry'
-      uses: docker/login-action@v1
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{github.actor}}
         password: ${{secrets.GITHUB_TOKEN}}
 
-    # Build the Docker image
-    - name: Build
+    # Push the Docker image to GitHub Container Registry
+    - name: Publish to GHCR
       run: |-
-        cd ./demo && docker build \
-          --tag "ghcr.io/diamonce/$REPO_IMAGE:$IMAGE_TAG-$OS-$ARCH" \
-          --build-arg GITHUB_SHA="$GITHUB_SHA" \
-          --build-arg GITHUB_REF="$GITHUB_REF" \
-          .
-
-    # Push the Docker image to Google Container Registry
-    - name: Publish
-      run: |-
+        docker tag "$GAR_ZONE-docker.pkg.dev/$PROJECT_ID/$GAR_REPO/$IMAGE:$IMAGE_TAG" "ghcr.io/diamonce/$REPO_IMAGE:$IMAGE_TAG-$OS-$ARCH"
         docker push ghcr.io/diamonce/$REPO_IMAGE:$IMAGE_TAG-$OS-$ARCH

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,21 @@
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.16.1
+    rev: v8.21.2
     hooks:
       - id: gitleaks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v5.0.0
     hooks:
-#    - id: check-yaml
+    - id: check-yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 24.10.0
     hooks:
     - id: black
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.62.2
+    hooks:
+    - id: golangci-lint
+      entry: golangci-lint run
+      types: [go]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+## [3.0.0] - 2026-02-08
+
+### Added
+- External configuration via JSON file (`demo/config.json`), loaded from `CONFIG_PATH` env var with hardcoded fallback
+- Health endpoints: `GET /healthz` (liveness) and `GET /readyz` (readiness)
+- Graceful shutdown with `signal.NotifyContext` for SIGINT/SIGTERM
+- Unit test suite (`demo/src/main_test.go`) with 11 tests covering all endpoints and config loading
+- Kubernetes liveness and readiness probes in deployment template
+- Kubernetes resource requests/limits (cpu: 50m/200m, memory: 64Mi/128Mi)
+- Kubernetes ConfigMap for externalizing service configuration
+- Go test and vet steps in GitHub Actions CI pipeline
+- `golangci-lint` pre-commit hook
+- `check-yaml` pre-commit hook (previously commented out)
+- Auto-refresh polling (every 30s) in frontend status page
+- Visual green/red circle status indicators in frontend
+- `<meta charset="utf-8">` and viewport meta tag in `index.html`
+- CA certificates in Docker image for HTTPS health checks
+
+### Fixed
+- **Critical**: Closure bug in service handler loop — all `/status/{id}` handlers previously resolved to the last service due to captured loop variable
+- Response body leak: `resp.Body.Close()` now called on all paths (including non-200 responses)
+- Proper HTTP error responses from `/status` endpoint (previously swallowed errors)
+
+### Changed
+- Bumped version from 2.0.0 to 3.0.0
+- Updated `go.mod` from Go 1.22.1 to Go 1.23
+- Switched from default `http.ServeMux` to `http.NewServeMux()` for testability
+- Pinned Docker builder image to `golang:1.23-alpine`
+- Status values changed from `"up /\"` / `"down \/"` to `"up"` / `"down"`
+- Updated `docker/login-action` from v1 to v3 in GitHub Actions
+- Removed duplicate Docker build step in CI (now tags and pushes existing image to GHCR)
+- Fixed duplicate step names in GitHub Actions workflow
+- Updated pre-commit hook versions: gitleaks v8.16.1 -> v8.21.2, pre-commit-hooks v2.3.0 -> v5.0.0, black 22.10.0 -> 24.10.0
+
+### Removed
+- `status:` section from Kubernetes deployment template (runtime state doesn't belong in a template)
+- `automountServiceAccountToken: true` replaced with `false` (not needed)
+- Removed `enableServiceLinks` and `shareProcessNamespace` from K8s template
+
+## [2.0.0]
+
+### Added
+- Initial Go web server with service status monitoring
+- Frontend with SVG animation (Vivus.js) and touch/keyboard navigation
+- Dockerfile with multi-stage build (scratch base)
+- Kubernetes deployment template
+- GitHub Actions CI/CD pipeline for GKE and GHCR
+- Pre-commit hooks (gitleaks, end-of-file-fixer, trailing-whitespace, black)

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,10 +1,14 @@
-FROM golang as builder
+FROM golang:1.23-alpine AS builder
 WORKDIR /src
 COPY src .
 RUN CGO_ENABLED=0 go build -o app
 
 FROM scratch
+LABEL maintainer="dchernenko"
+LABEL version="3.0.0"
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ADD ./html /html
+COPY config.json .
 COPY --from=builder /src/app .
 ENTRYPOINT ["/app"]
 EXPOSE 8088

--- a/demo/config.json
+++ b/demo/config.json
@@ -1,0 +1,25 @@
+{
+  "servers": [
+    {
+      "serviceId": "dc_depops_sp",
+      "serviceName": "DevOps та Kubernetes 3.0 Status Page",
+      "ipAddress": "34.116.191.131",
+      "port": 80,
+      "protocol": "http"
+    },
+    {
+      "serviceId": "google",
+      "serviceName": "Google",
+      "ipAddress": "google.com",
+      "port": 80,
+      "protocol": "http"
+    },
+    {
+      "serviceId": "olekluk",
+      "serviceName": "OlekLUk",
+      "ipAddress": "34.133.93.117",
+      "port": 80,
+      "protocol": "http"
+    }
+  ]
+}

--- a/demo/deploy/go_demo_template.yaml
+++ b/demo/deploy/go_demo_template.yaml
@@ -1,7 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: go-demo-config
+  namespace: default
+data:
+  config.json: |
+    {
+      "servers": [
+        {
+          "serviceId": "dc_depops_sp",
+          "serviceName": "DevOps та Kubernetes 3.0 Status Page",
+          "ipAddress": "34.116.191.131",
+          "port": 80,
+          "protocol": "http"
+        },
+        {
+          "serviceId": "google",
+          "serviceName": "Google",
+          "ipAddress": "google.com",
+          "port": 80,
+          "protocol": "http"
+        },
+        {
+          "serviceId": "olekluk",
+          "serviceName": "OlekLUk",
+          "ipAddress": "34.133.93.117",
+          "port": 80,
+          "protocol": "http"
+        }
+      ]
+    }
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  generation: 1
   labels:
     app: go
   name: go-demo
@@ -20,11 +52,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: go
     spec:
-      automountServiceAccountToken: true
+      automountServiceAccountToken: false
       containers:
         - image: europe-central2-docker.pkg.dev/ethereal-runner-417315/dc-docker-repo/demo_app:production
           imagePullPolicy: Always
@@ -32,19 +63,39 @@ spec:
           ports:
             - containerPort: 8088
               protocol: TCP
-          resources: {}
+          env:
+            - name: CONFIG_PATH
+              value: /config/config.json
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8088
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8088
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          volumeMounts:
+            - name: config-volume
+              mountPath: /config
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+      volumes:
+        - name: config-volume
+          configMap:
+            name: go-demo-config
       dnsPolicy: ClusterFirst
-      enableServiceLinks: true
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      shareProcessNamespace: false
       terminationGracePeriodSeconds: 30
-status:
-  availableReplicas: 3
-  observedGeneration: 1
-  readyReplicas: 3
-  replicas: 3
-  updatedReplicas: 3

--- a/demo/html/index.html
+++ b/demo/html/index.html
@@ -2,6 +2,8 @@
 <html>
 <!-- This should work everywhere -->
 <head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<script type="text/javascript" src="./vivus.min.js"></script>
   <script type="text/javascript" src="status.js"></script>
   <script type="text/javascript">

--- a/demo/html/status.js
+++ b/demo/html/status.js
@@ -1,13 +1,24 @@
 document.addEventListener('DOMContentLoaded', function() {
+    fetchAllStatuses();
+    setInterval(fetchAllStatuses, 30000);
+});
+
+function fetchAllStatuses() {
     fetch('/status')
         .then(response => response.json())
         .then(serviceIds => {
+            clearTable();
             serviceIds.forEach(serviceId => {
                 fetchServiceStatus(serviceId);
             });
         })
         .catch(error => console.error('Error fetching service IDs:', error));
-});
+}
+
+function clearTable() {
+    const tableBody = document.getElementById('statusTable').getElementsByTagName('tbody')[0];
+    tableBody.innerHTML = '';
+}
 
 function fetchServiceStatus(serviceId) {
     fetch(`/status/${serviceId}`)
@@ -26,6 +37,17 @@ function updateTable(serviceId, data) {
     const statusCell = row.insertCell(2);
 
     serviceIdCell.textContent = serviceId;
-    serviceNameCell.textContent = data.service_name; // Adjust based on actual response structure
-    statusCell.textContent = data.status; // Adjust based on actual response structure
+    serviceNameCell.textContent = data.service_name;
+
+    const isUp = data.status === 'up';
+    const indicator = document.createElement('span');
+    indicator.style.display = 'inline-block';
+    indicator.style.width = '12px';
+    indicator.style.height = '12px';
+    indicator.style.borderRadius = '50%';
+    indicator.style.marginRight = '8px';
+    indicator.style.backgroundColor = isUp ? '#22c55e' : '#ef4444';
+
+    statusCell.appendChild(indicator);
+    statusCell.appendChild(document.createTextNode(isUp ? 'Up' : 'Down'));
 }

--- a/demo/src/go.mod
+++ b/demo/src/go.mod
@@ -1,3 +1,3 @@
 module demo
 
-go 1.22.1
+go 1.23

--- a/demo/src/main_test.go
+++ b/demo/src/main_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+func TestCheckServiceUp(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	svc := Service{
+		ServiceId:   "test",
+		ServiceName: "Test Service",
+		IPAddress:   ts.Listener.Addr().String(),
+		Port:        0, // port is already in the address
+		Protocol:    "http",
+	}
+
+	// Override URL format: httptest includes port in address
+	result, err := checkServiceURL(svc, ts.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if data["status"] != "up" {
+		t.Errorf("expected status 'up', got %q", data["status"])
+	}
+	if data["service_name"] != "Test Service" {
+		t.Errorf("expected service_name 'Test Service', got %q", data["service_name"])
+	}
+}
+
+func TestCheckServiceDown(t *testing.T) {
+	svc := Service{
+		ServiceId:   "down",
+		ServiceName: "Down Service",
+		IPAddress:   "127.0.0.1",
+		Port:        1, // nothing listening
+		Protocol:    "http",
+	}
+
+	result, err := checkService(svc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(result, &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if data["status"] != "down" {
+		t.Errorf("expected status 'down', got %q", data["status"])
+	}
+}
+
+func TestVersionEndpoint(t *testing.T) {
+	cfg := Config{Servers: []Service{}}
+	mux := newMux(cfg)
+
+	req := httptest.NewRequest("GET", "/version", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if data["Version"] != "3.0.0" {
+		t.Errorf("expected version '3.0.0', got %q", data["Version"])
+	}
+}
+
+func TestStatusEndpoint(t *testing.T) {
+	cfg := Config{
+		Servers: []Service{
+			{ServiceId: "svc1", ServiceName: "Service 1"},
+			{ServiceId: "svc2", ServiceName: "Service 2"},
+		},
+	}
+	mux := newMux(cfg)
+
+	req := httptest.NewRequest("GET", "/status", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	var ids []string
+	if err := json.Unmarshal(w.Body.Bytes(), &ids); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 service IDs, got %d", len(ids))
+	}
+	if ids[0] != "svc1" || ids[1] != "svc2" {
+		t.Errorf("unexpected IDs: %v", ids)
+	}
+}
+
+func TestStatusServiceEndpoint(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	host, portStr, _ := net.SplitHostPort(ts.Listener.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+
+	cfg := Config{
+		Servers: []Service{
+			{
+				ServiceId:   "test_svc",
+				ServiceName: "Test",
+				IPAddress:   host,
+				Port:        port,
+				Protocol:    "http",
+			},
+		},
+	}
+	mux := newMux(cfg)
+
+	req := httptest.NewRequest("GET", "/status/test_svc", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &data); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if data["service_name"] != "Test" {
+		t.Errorf("expected service_name 'Test', got %q", data["service_name"])
+	}
+}
+
+func TestHealthzEndpoint(t *testing.T) {
+	cfg := Config{Servers: []Service{}}
+	mux := newMux(cfg)
+
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestReadyzEndpoint(t *testing.T) {
+	cfg := Config{Servers: []Service{}}
+
+	// configLoaded is set by loadConfig; set it manually for test
+	configLoaded = true
+	mux := newMux(cfg)
+
+	req := httptest.NewRequest("GET", "/readyz", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestReadyzNotReady(t *testing.T) {
+	cfg := Config{Servers: []Service{}}
+
+	configLoaded = false
+	mux := newMux(cfg)
+
+	req := httptest.NewRequest("GET", "/readyz", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503, got %d", w.Code)
+	}
+
+	// Reset for other tests
+	configLoaded = true
+}
+
+func TestLoadConfigValidFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	data := `{"servers":[{"serviceId":"test","serviceName":"Test","ipAddress":"1.2.3.4","port":80,"protocol":"http"}]}`
+	if err := os.WriteFile(cfgPath, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CONFIG_PATH", cfgPath)
+	cfg := loadConfig()
+
+	if len(cfg.Servers) != 1 {
+		t.Fatalf("expected 1 server, got %d", len(cfg.Servers))
+	}
+	if cfg.Servers[0].ServiceId != "test" {
+		t.Errorf("expected serviceId 'test', got %q", cfg.Servers[0].ServiceId)
+	}
+}
+
+func TestLoadConfigMissingFile(t *testing.T) {
+	t.Setenv("CONFIG_PATH", "/nonexistent/config.json")
+	cfg := loadConfig()
+
+	if len(cfg.Servers) != 3 {
+		t.Errorf("expected 3 default servers, got %d", len(cfg.Servers))
+	}
+}
+
+func TestLoadConfigInvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	if err := os.WriteFile(cfgPath, []byte("not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("CONFIG_PATH", cfgPath)
+	cfg := loadConfig()
+
+	if len(cfg.Servers) != 3 {
+		t.Errorf("expected 3 default servers, got %d", len(cfg.Servers))
+	}
+}


### PR DESCRIPTION
## Summary
- **Fix critical closure bug**: all `/status/{id}` handlers previously resolved to the last service due to captured loop variable
- **Add external config**: load services from `config.json` via `CONFIG_PATH` env var, with hardcoded fallback
- **Add health endpoints**: `/healthz` (liveness) and `/readyz` (readiness) for Kubernetes probes
- **Add graceful shutdown**: `signal.NotifyContext` for clean SIGINT/SIGTERM handling
- **Add unit tests**: 11 tests covering all endpoints, config loading (valid/missing/invalid), and service checks
- **Modernize Dockerfile**: pin `golang:1.23-alpine`, add CA certs, include `config.json`
- **Modernize K8s template**: add resource limits, liveness/readiness probes, ConfigMap for config, remove runtime `status:` section
- **Modernize CI/CD**: add Go test/vet steps, update `docker/login-action` v1→v3, remove duplicate build step
- **Update pre-commit hooks**: gitleaks v8.21.2, pre-commit-hooks v5.0.0, black 24.10.0, add golangci-lint and check-yaml
- **Improve frontend**: 30s auto-refresh polling, green/red status indicators, meta charset and viewport tags
- **Bump version**: 2.0.0 → 3.0.0

## Test plan
- [x] `go test -v ./...` — 11/11 tests pass
- [x] `go vet ./...` — clean
- [ ] `docker build` and run locally, verify `/healthz`, `/version`, `/status` endpoints
- [ ] Verify frontend auto-refresh and status indicators in browser
- [ ] Deploy to staging and verify K8s probes